### PR TITLE
 [PI-103] Broadcasting of encoded stx

### DIFF
--- a/blockchain-importer/src/Pos/BlockchainImporter/Aeson/ClientTypes.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Aeson/ClientTypes.hs
@@ -9,25 +9,27 @@ import           Universum
 
 import           Data.Aeson.Encoding (unsafeToEncoding)
 import           Data.Aeson.TH (defaultOptions, deriveJSON, deriveToJSON)
-import           Data.Aeson.Types (Parser, Value (String), typeMismatch, ToJSON (..), FromJSON (..))
-import qualified Data.ByteString.Builder as BS (string8)
+import           Data.Aeson.Types (FromJSON (..), Parser, ToJSON (..), Value (String), typeMismatch)
 import qualified Data.ByteString.Base64.Lazy as B64
+import qualified Data.ByteString.Builder as BS (string8)
+import qualified Data.ByteString.Lazy as BSL
 import           Data.Fixed (showFixed)
 import qualified Data.Text.Lazy.Encoding as TE
 
 import           Pos.Aeson ()
 import           Pos.Aeson.Txp ()
-import           Pos.BlockchainImporter.Web.ClientTypes (CAda (..), CAddress, CAddressSummary, CAddressType,
-                                               CBlockEntry, CBlockSummary, CCoin,
-                                               CGenesisAddressInfo, CGenesisSummary, CHash,
-                                               CNetworkAddress, CTxBrief, CTxEntry, CTxId,
-                                               CTxSummary, CSignedEncTx, CEncodedData (..))
+import           Pos.BlockchainImporter.Web.ClientTypes (CAda (..), CAddress, CAddressSummary,
+                                                         CAddressType, CBlockEntry, CBlockSummary,
+                                                         CCoin, CEncodedSTx (..),
+                                                         CGenesisAddressInfo, CGenesisSummary,
+                                                         CHash, CNetworkAddress, CTxBrief, CTxEntry,
+                                                         CTxId, CTxSummary)
 import           Pos.BlockchainImporter.Web.Error (BlockchainImporterError)
 
 deriveJSON defaultOptions ''CHash
 deriveJSON defaultOptions ''CAddress
 deriveJSON defaultOptions ''CTxId
-deriveJSON defaultOptions ''CSignedEncTx
+deriveJSON defaultOptions ''CEncodedSTx
 
 deriveToJSON defaultOptions ''CCoin
 deriveToJSON defaultOptions ''BlockchainImporterError
@@ -49,18 +51,19 @@ instance ToJSON CAda where
         BS.string8 &         -- convert String to ByteString using Latin1 encoding
         unsafeToEncoding     -- convert ByteString to Aeson's Encoding
 
-instance ToJSON CEncodedData where
-    toJSON (CEncodedData bs) = String $ toStrict $ TE.decodeUtf8 $ B64.encode bs
-    
-instance FromJSON CEncodedData where
-    parseJSON (String encodedData) = fromRawEncodedData encodedData
-    parseJSON x                    = typeMismatch "Not a valid CEncodedData" x
-    
-fromRawEncodedData :: Text -> Parser CEncodedData
-fromRawEncodedData rawEncodedData = do
-    let lazyRawEncData    = fromStrict rawEncodedData
+-- JSON instances for ByteString, it is encoded to base 64
+instance ToJSON BSL.ByteString where
+  toJSON bs = String $ toStrict $ TE.decodeUtf8 $ B64.encode bs
+
+instance FromJSON BSL.ByteString where
+  parseJSON (String encodedData) = fromBase64Data encodedData
+  parseJSON x                    = typeMismatch "Not a valid ByteString" x
+
+fromBase64Data :: Text -> Parser BSL.ByteString
+fromBase64Data base64EncodedData = do
+    let lazyRawEncData    = fromStrict base64EncodedData
         utf8EncRawData    = TE.encodeUtf8 $ lazyRawEncData
         maybeBase64DecRaw = B64.decode $ utf8EncRawData
     case maybeBase64DecRaw of
-        Right base64DecRaw -> pure $ CEncodedData $ base64DecRaw
+        Right base64DecRaw -> pure $ base64DecRaw
         Left e             -> fail e

--- a/blockchain-importer/src/Pos/BlockchainImporter/Web/Api.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Web/Api.hs
@@ -15,16 +15,18 @@ import           Universum
 
 import           Control.Exception.Safe (try)
 import           Data.Proxy (Proxy (Proxy))
-import           Servant.API ((:>), Capture, Get, Post, JSON, QueryParam, ReqBody, Summary)
+import           Servant.API ((:>), Capture, Get, JSON, Post, QueryParam, ReqBody, Summary)
 import           Servant.Generic ((:-), AsApi, ToServant)
 import           Servant.Server (ServantErr (..))
 
-import           Pos.Core (EpochIndex)
 import           Pos.BlockchainImporter.Web.ClientTypes (Byte, CAda, CAddress, CAddressSummary,
-                                               CAddressesFilter, CBlockEntry, CBlockSummary,
-                                               CGenesisAddressInfo, CGenesisSummary, CHash,
-                                               CTxBrief, CTxEntry, CTxId, CTxSummary, CSignedEncTx)
+                                                         CAddressesFilter, CBlockEntry,
+                                                         CBlockSummary, CEncodedSTx,
+                                                         CGenesisAddressInfo, CGenesisSummary,
+                                                         CHash, CTxBrief, CTxEntry, CTxId,
+                                                         CTxSummary)
 import           Pos.BlockchainImporter.Web.Error (BlockchainImporterError)
+import           Pos.Core (EpochIndex)
 import           Pos.Util.Servant (DQueryParam, ModifiesApiRes (..), VerbMod)
 
 type PageNumber = Integer
@@ -164,8 +166,8 @@ data BlockchainImporterApiRecord route = BlockchainImporterApiRecord
   , _sendSignedTx :: route
         :- "txs"
         :> "signed"
-        :> ReqBody '[JSON] CSignedEncTx 
-        :> ExRes Post Bool 
+        :> ReqBody '[JSON] CEncodedSTx
+        :> ExRes Post Bool
   }
   deriving (Generic)
 

--- a/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
@@ -55,17 +55,17 @@ import           Pos.Crypto (WithHash (..), hash, redeemPkBuild, withHash)
 import           Pos.DB.Block (getBlund)
 import           Pos.DB.Class (MonadDBRead)
 
-import           Pos.Diffusion.Types (Diffusion(..))
+import           Pos.Diffusion.Types (Diffusion (..))
 
 import           Pos.Binary.Class (biSize)
 import           Pos.Block.Types (Blund, Undo)
-import           Pos.Core (AddrType (..), Address (..), TxAux (..), Coin, EpochIndex, HeaderHash, Timestamp,
-                           coinToInteger, difficultyL, gbHeader, gbhConsensus, getChainDifficulty,
-                           isUnknownAddressType, makeRedeemAddress, siEpoch, siSlot, sumCoins,
-                           timestampToPosix, unsafeAddCoin, unsafeIntegerToCoin, unsafeSubCoin)
+import           Pos.Core (AddrType (..), Address (..), Coin, EpochIndex, HeaderHash, Timestamp,
+                           TxAux (..), coinToInteger, difficultyL, gbHeader, gbhConsensus,
+                           getChainDifficulty, isUnknownAddressType, makeRedeemAddress, siEpoch,
+                           siSlot, sumCoins, timestampToPosix, unsafeAddCoin, unsafeIntegerToCoin,
+                           unsafeSubCoin)
 import           Pos.Core.Block (Block, MainBlock, mainBlockSlot, mainBlockTxPayload, mcdSlot)
-import           Pos.Core.Txp (Tx (..), TxId, TxOutAux (..), taTx, txOutValue, txpTxs,
-                               _txOutputs)
+import           Pos.Core.Txp (Tx (..), TxId, TxOutAux (..), taTx, txOutValue, txpTxs, _txOutputs)
 import           Pos.Slotting (MonadSlots (..), getSlotStart)
 import           Pos.Txp (MonadTxpMem, TxMap, getLocalTxs, getMemPool, mpLocalTxs, topsortTxs,
                           withTxpLocalData)
@@ -74,23 +74,28 @@ import           Pos.Util.Chrono (NewestFirst (..))
 import           Pos.Web (serveImpl)
 
 import           Pos.BlockchainImporter.Aeson.ClientTypes ()
+import           Pos.BlockchainImporter.BlockchainImporterMode (BlockchainImporterMode)
 import           Pos.BlockchainImporter.Core (TxExtra (..))
 import           Pos.BlockchainImporter.DB (Page, defaultPageSize, getAddrBalance, getAddrHistory,
-                                  getLastTransactions, getTxExtra, getUtxoSum)
-import           Pos.BlockchainImporter.BlockchainImporterMode (BlockchainImporterMode)
+                                            getLastTransactions, getTxExtra, getUtxoSum)
 import           Pos.BlockchainImporter.ExtraContext (HasBlockchainImporterCSLInterface (..),
-                                            HasGenesisRedeemAddressInfo (..))
-import           Pos.BlockchainImporter.Web.Api (BlockchainImporterApi, BlockchainImporterApiRecord (..), blockchainImporterApi)
-import           Pos.BlockchainImporter.Web.ClientTypes (Byte, CAda (..), CAddress (..), CAddressSummary (..),
-                                               CAddressType (..), CAddressesFilter (..),
-                                               CBlockEntry (..), CBlockSummary (..),
-                                               CGenesisAddressInfo (..), CGenesisSummary (..),
-                                               CHash, CTxBrief (..), CTxEntry (..), CTxId (..),
-                                               CTxSummary (..), TxInternal (..), CSignedEncTx (..), CEncodedData (..),
-                                               convertTxOutputs, convertTxOutputsMB, fromCAddress, fromCHash,
-                                               fromCTxId, getEpochIndex, getSlotIndex, mkCCoin,
-                                               mkCCoinMB, tiToTxEntry, toBlockEntry, toBlockSummary,
-                                               toCAddress, toCHash, toCTxId, toTxBrief)
+                                                      HasGenesisRedeemAddressInfo (..))
+import           Pos.BlockchainImporter.Web.Api (BlockchainImporterApi,
+                                                 BlockchainImporterApiRecord (..),
+                                                 blockchainImporterApi)
+import           Pos.BlockchainImporter.Web.ClientTypes (Byte, CAda (..), CAddress (..),
+                                                         CAddressSummary (..), CAddressType (..),
+                                                         CAddressesFilter (..), CBlockEntry (..),
+                                                         CBlockSummary (..), CEncodedSTx (..),
+                                                         CGenesisAddressInfo (..),
+                                                         CGenesisSummary (..), CHash, CTxBrief (..),
+                                                         CTxEntry (..), CTxId (..), CTxSummary (..),
+                                                         TxInternal (..), convertTxOutputs,
+                                                         convertTxOutputsMB, fromCAddress,
+                                                         fromCHash, fromCTxId, getEpochIndex,
+                                                         getSlotIndex, mkCCoin, mkCCoinMB,
+                                                         tiToTxEntry, toBlockEntry, toBlockSummary,
+                                                         toCAddress, toCHash, toCTxId, toTxBrief)
 import           Pos.BlockchainImporter.Web.Error (BlockchainImporterError (..))
 
 
@@ -740,12 +745,11 @@ getStatsTxs mPageNumber = do
 
 sendSignedTx
      :: BlockchainImporterMode ctx m
-     => Diffusion m 
-     -> CSignedEncTx
+     => Diffusion m
+     -> CEncodedSTx
      -> m Bool
-sendSignedTx Diffusion{..} (CSignedEncTx (CEncodedData encodedTx) txWitness) = do
-    let maybeTx    = Bi.decodeFull encodedTx
-        maybeTxAux = flip TxAux txWitness <$> maybeTx
+sendSignedTx Diffusion{..} (CEncodedSTx encodedSTx) = do
+    let maybeTxAux = Bi.decodeFull encodedSTx
     case maybeTxAux of
       Right txAux ->
         -- This is done for two reasons:

--- a/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
@@ -748,8 +748,8 @@ sendSignedTx
      => Diffusion m
      -> CEncodedSTx
      -> m Bool
-sendSignedTx Diffusion{..} (CEncodedSTx encodedSTx) = do
-    let maybeTxAux = Bi.decodeFull encodedSTx
+sendSignedTx Diffusion{..} encodedSTx = do
+    let maybeTxAux = Bi.decodeFull $ Bi.serialize encodedSTx
     case maybeTxAux of
       Right txAux ->
         -- This is done for two reasons:


### PR DESCRIPTION
## Description

Transactions are sent to the node to be broadcasted through a base64 CBOR of the signed tx. An example usage is:
```
curl -H 'Content-Type: application/json' -X POST http://localhost:8200/api/txs/signed -d '{ "signedTx": "goOfggDYGFglglggHHsXjBZVYoyofH2mpdnRPB4KMECUrIh3B2jVZePSDgsYKv+fgoLYGFg3g1gcW3afwvA4JJUN9AjeajanLdED8y/JnjG1CB0MW6EBVFMPQMnp1ZLEeiWMhV/6TYf6qMd+ABqPqBKdAYKC2BhYN4NYHFt2n8LwOCSVDfQI3mo2py3RA/MvyZ4xtQgdDFuhAVRTD0DJ6dWSxHoljIVf+k2H+qjHfgAaj6gSnRoAAocggoLYGFg3g1gcW3afwvA4JJUN9AjeajanLdED8y/JnjG1CB0MW6EBVFMPQMnp1ZLEeiWMhV/6TYf6qMd+ABqPqBKdGgWGDsP/oIGCANgYWIWCWEB+fe4L86lq3JdBdUbjWH6kn+WErGeI/WiYjUNT6jgs1ZeKREGl4LxFUclVKcAGOUzfIXETJcD9RNJfv9NnhHRwWECc/FiOnOmMibBGLcdosYEzcjb6jgSjmu9YKqTAE3ekg7+ai09wZjXQ6BdnOzR0Mwlm13nRMso1z5+bEsgxSukH" }'
```