### PR TITLE
[PI-109] Validate tx to broadcast

### DIFF
--- a/blockchain-importer/cardano-sl-blockchain-importer.cabal
+++ b/blockchain-importer/cardano-sl-blockchain-importer.cabal
@@ -65,6 +65,7 @@ library
                       , conduit
                       , containers
                       , data-default
+                      , errors
                       , ether >= 0.5.1
                       , exceptions
                       , formatting

--- a/blockchain-importer/src/Pos/BlockchainImporter/Web/Api.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Web/Api.hs
@@ -167,7 +167,7 @@ data BlockchainImporterApiRecord route = BlockchainImporterApiRecord
         :- "txs"
         :> "signed"
         :> ReqBody '[JSON] CEncodedSTx
-        :> ExRes Post Bool
+        :> ExRes Post ()
   }
   deriving (Generic)
 

--- a/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Web/Server.hs
@@ -32,6 +32,7 @@ module Pos.BlockchainImporter.Web.Server
 
 import           Universum
 
+import           Control.Error.Util (exceptT, hoistEither)
 import           Control.Lens (at)
 import qualified Data.ByteString as BS
 import qualified Data.HashMap.Strict as HM
@@ -749,29 +750,24 @@ sendSignedTx
      => Diffusion m
      -> CEncodedSTx
      -> m ()
-sendSignedTx Diffusion{..} encodedSTx = do
-    let maybeTxAux = decodeSTx encodedSTx
-    case maybeTxAux of
-      Right txAux -> do
-        let txHash = hash $ taTx txAux
-        -- FIXME: We are using only the confirmed UTxO,
-        --        we should also take into account the pending txs
-        isValidTx <- runExceptT $ verifyTx getTxOut False txAux
-        case isValidTx of
-          Right _              -> do
-            -- This is done for two reasons:
-            -- 1. In order not to overflow relay.
-            -- 2. To let other things (e. g. block processing) happen if
-            -- `newPayment`s are done continuously.
-            wasAccepted <- notFasterThan (6 :: Second) $ sendTx txAux
-            unless  wasAccepted $
-                    throwM $ Internal $ sformat ("Tx broadcasted "%build%", not accepted by any peer")
-                                                txHash
-            return ()
-          Left validationError ->
-            throwM $ Internal $ sformat ("Tx not broadcasted "%build%": "%build)
-                                        txHash validationError
-      Left _ -> throwM $ Internal "Tx not broadcasted: invalid encoded tx"
+sendSignedTx Diffusion{..} encodedSTx =
+  exceptT' (hoistEither $ decodeSTx encodedSTx) (const $ throwM eInvalidEnc) $ \txAux -> do
+    let txHash = hash $ taTx txAux
+    -- FIXME: We are using only the confirmed UTxO, we should also take into account the pending txs
+    exceptT' (verifyTx getTxOut False txAux) (throwM . eInvalidTx txHash) $ \_ -> do
+      -- This is done for two reasons:
+      -- 1. In order not to overflow relay.
+      -- 2. To let other things (e. g. block processing) happen if
+      -- `newPayment`s are done continuously.
+      wasAccepted <- notFasterThan (6 :: Second) $ sendTx txAux
+      void $ unless wasAccepted $ (throwM $ eNotAccepted txHash)
+        where eInvalidEnc = Internal "Tx not broadcasted: invalid encoded tx"
+              eInvalidTx txHash reason = Internal $
+                  sformat ("Tx not broadcasted "%build%": "%build) txHash reason
+              eNotAccepted txHash = Internal $
+                  sformat  ("Tx broadcasted "%build%", not accepted by any peer") txHash
+              exceptT' e f g = exceptT f g e
+
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/txp/Pos/Txp/Toil/Logic.hs
+++ b/txp/Pos/Txp/Toil/Logic.hs
@@ -138,8 +138,13 @@ verifyAndApplyTx adoptedBVD curEpoch verifyVersions tx@(_, txAux) = do
   where
     ctx = Utxo.VTxContext verifyVersions
 
--- FIXME: Check missing validations
--- Verifies that a tx is valid
+{-  Verifies that a tx is valid
+    All validations from 'verifyAndApplyTx' are incorporated, except the ones
+    that require the block in which it will be incorporated:
+      - Verifying the tx fee
+      - Verifying the tx size
+      - If we are in the bootstrap era, checking the addresses used
+-}
 verifyTx ::
        (HasConfiguration, Monad m)
     => (TxIn -> m (Maybe TxOutAux))


### PR DESCRIPTION
## Description

Include validations of txs before broadcasting them, all validations done to txs are incorporated, except the ones that require to now the block in which it will be incorporated:
- Verifying the tx fee
- Verifying the tx size
- If we are in the bootstrap era, checking the addresses used

*Note*: Only confirmed UTxOs are use for the validation, so txs with inputs from pending txs will be rejected (to be changed in [PI-112](https://iohk.myjetbrains.com/youtrack/issue/PI-112))