### PR TITLE
[PI-117] Changed default notifier port to 8210

### DIFF
--- a/blockchain-importer/src/blockchain-importer/BlockchainImporterNodeOptions.hs
+++ b/blockchain-importer/src/blockchain-importer/BlockchainImporterNodeOptions.hs
@@ -74,7 +74,7 @@ blockchainImporterArgsParser = do
     notifierPort   <- option auto $
         long    "notifier-port" <>
         metavar "PORT" <>
-        value   8200 <> showDefault <>
+        value   8210 <> showDefault <>
         help    "Port for update notifier, the socket.io backend."
     postGresConfig <- connectInfoParser
     pure $ BlockchainImporterNodeArgs commonNodeArgs BlockchainImporterArgs{..}


### PR DESCRIPTION
## Description

Both the blockchain importer and the [update notifier](https://cardanodocs.com/technical/explorer/#socketio-api) had the same port `8200` configured, changed the latter one to `8210`.

This caused only one of the two processes to run, whoever got the resource first. In the unusual case that the notifier started, the blockchain importer wasn't, so it didn't respond to any HTTP query.