### PR TITLE
[PI-304] Remove starting block option

### DIFF
--- a/blockchain-importer/bench/Bench/Pos/BlockchainImporter/ServerBench.hs
+++ b/blockchain-importer/bench/Bench/Pos/BlockchainImporter/ServerBench.hs
@@ -37,7 +37,7 @@ getBlocksTotalBench
 getBlocksTotalBench (testParams, extraContext) =
     withDefConfigurations $ \_ ->
       -- Postgres db is not mocked as it's never used
-      withPostGresDB (error "No postgres db configured") 0 $
+      withPostGresDB (error "No postgres db configured") $
         runBlockchainImporterTestMode testParams extraContext getBlocksTotal
 
 -- | This is used to generate the test environment. We don't do this while benchmarking
@@ -56,7 +56,7 @@ generateTestParams totalBlocksNumber slotsPerEpoch = do
     -- The extra context so we can mock the functions.
     -- Postgres db is not mocked as it's never used
     let extraContext :: ExtraContext
-        extraContext = withPostGresDB (error "No postgres db configured") 0 $
+        extraContext = withPostGresDB (error "No postgres db configured") $
                           withDefConfigurations $ const $ makeMockExtraCtx mode
 
     pure (testParams, extraContext)

--- a/blockchain-importer/src/Pos/BlockchainImporter/Configuration.hs
+++ b/blockchain-importer/src/Pos/BlockchainImporter/Configuration.hs
@@ -7,7 +7,6 @@ module Pos.BlockchainImporter.Configuration
        , withPostGresDB
        , withPostGreTransaction
        , withPostGreTransactionM
-       , maybePostGreStore
        , postGreOperate
        ) where
 
@@ -17,31 +16,16 @@ import           Data.Reflection (Given (..), give, given)
 import qualified Database.PostgreSQL.Simple as PGS
 import           UnliftIO (MonadUnliftIO, withRunInIO)
 
-import           Pos.Core (BlockCount)
-
-type HasPostGresDB = Given PostGresDBConfiguration
-
-data PostGresDBConfiguration = PostGresDBConfiguration
-    {
-      pgConnection :: !PGS.Connection
-      -- ^ Connection to PostGres DB
-    , pgStartBlock :: !BlockCount
-      -- ^ Starting block number from which data will be stored on the DB
-    }
+type HasPostGresDB = Given PGS.Connection
 
 withPostGreTransaction :: HasPostGresDB => IO a -> IO a
-withPostGreTransaction = PGS.withTransaction (pgConnection given)
+withPostGreTransaction = PGS.withTransaction given
 
 withPostGreTransactionM :: forall m . (MonadUnliftIO m, MonadIO m, HasPostGresDB) => m () -> m ()
 withPostGreTransactionM m = withRunInIO $ \runInIO -> withPostGreTransaction $ runInIO m
 
-maybePostGreStore :: HasPostGresDB => BlockCount -> (PGS.Connection -> IO ()) -> IO ()
-maybePostGreStore currBN storeFn
-  | (fromIntegral currBN) >= (pgStartBlock given)  = postGreOperate storeFn
-  | otherwise                                      = pure ()
-
 postGreOperate :: HasPostGresDB => (PGS.Connection -> IO a) -> IO a
-postGreOperate storeFn = storeFn $ pgConnection given
+postGreOperate storeFn = storeFn given
 
-withPostGresDB :: PGS.Connection -> BlockCount -> (HasPostGresDB => r) -> r
-withPostGresDB conn startBlock = give $ PostGresDBConfiguration conn startBlock
+withPostGresDB :: PGS.Connection -> (HasPostGresDB => r) -> r
+withPostGresDB = give

--- a/blockchain-importer/src/blockchain-importer/BlockchainImporterNodeOptions.hs
+++ b/blockchain-importer/src/blockchain-importer/BlockchainImporterNodeOptions.hs
@@ -21,8 +21,6 @@ import           Options.Applicative (Parser, auto, execParser, flag, footerDoc,
 import           Paths_cardano_sl_blockchain_importer (version)
 import           Pos.Client.CLI (CommonNodeArgs (..))
 import qualified Pos.Client.CLI as CLI
-import           Pos.Core (BlockCount (..))
-
 
 data BlockchainImporterNodeArgs = BlockchainImporterNodeArgs
     { enaCommonNodeArgs         :: !CommonNodeArgs
@@ -35,8 +33,6 @@ data BlockchainImporterArgs = BlockchainImporterArgs
     -- ^ The port for the blockchainImporter backend
     , postGresConfig          :: !PGS.ConnectInfo
     -- ^ Configuration of the PostGres DB
-    , storingStartBlockPG     :: !BlockCount
-    -- ^ Starting block number from which data will be stored on the DB
     , recoveryMode            :: !Bool
     -- ^ Enable importer recovery mode
     , disableConsistencyCheck :: !Bool
@@ -78,11 +74,6 @@ blockchainImporterArgsParser = do
     commonNodeArgs <- CLI.commonNodeArgsParser
     webPort        <- CLI.webPortOption 8200 "Port for web API."
     postGresConfig <- connectInfoParser
-    storingStartBlockPG     <- option (BlockCount <$> auto) $
-        long    "postgres-startblock" <>
-        metavar "PS-START-NUM" <>
-        value   0 <>
-        help    "First block whose info will be stored on postgres DB."
     recoveryMode <- flag False True $
         long "recovery-mode" <>
         help "Enable recovery mode"

--- a/blockchain-importer/src/blockchain-importer/Main.hs
+++ b/blockchain-importer/src/blockchain-importer/Main.hs
@@ -63,7 +63,7 @@ action :: BlockchainImporterNodeArgs -> Production ()
 action (BlockchainImporterNodeArgs (cArgs@CommonNodeArgs{..}) BlockchainImporterArgs{..}) =
     withConfigurations conf $ \ntpConfig -> do
       conn <- liftIO $ PGS.connect postGresConfig
-      withPostGresDB conn storingStartBlockPG $
+      withPostGresDB conn $
         withCompileInfo $(retrieveCompileTimeInfo) $ do
             CLI.printInfoOnStart cArgs ntpConfig
             logInfo "Blockchain importer is enabled!"

--- a/blockchain-importer/src/importer-db-consistency/Main.hs
+++ b/blockchain-importer/src/importer-db-consistency/Main.hs
@@ -62,7 +62,7 @@ action :: ImporterDBConsistencyNodeArgs -> Production ()
 action (ImporterDBConsistencyNodeArgs (cArgs@CommonNodeArgs{..}) ImporterDBConsistencyArgs{..}) =
     withConfigurations conf $ \ntpConfig -> do
       conn <- liftIO $ PGS.connect postGresConfig
-      withPostGresDB conn 0 $ -- Starting block number not used on consistency checks
+      withPostGresDB conn $
         withCompileInfo $(retrieveCompileTimeInfo) $ do
             CLI.printInfoOnStart cArgs ntpConfig
             logInfo "Blockchain importer is enabled!"

--- a/blockchain-importer/test/Test/Pos/BlockchainImporter/Web/ServerSpec.hs
+++ b/blockchain-importer/test/Test/Pos/BlockchainImporter/Web/ServerSpec.hs
@@ -41,7 +41,7 @@ import           Test.Pos.Configuration (withDefConfigurations)
 spec :: Spec
 spec = withDefConfigurations $ \_ ->
         -- Postgres db is not mocked as it's never used
-        withPostGresDB (error "No postgres db configured") 0 $ do
+        withPostGresDB (error "No postgres db configured") $ do
     describe "Pos.BlockchainImporter.Web.Server" $ do
         blocksTotalSpec
         blocksPagesTotalSpec


### PR DESCRIPTION
## Description

Remove option to select starting block for storing data on the postgres db.

This option was originally added for having the importer up-to-date faster without having any back-up. As the plan for recovery requires a back-up node and gives support to that, the original plan is no longer needed.