### PR TITLE
[PI-306] Add testnet support

### DIFF
--- a/lib/configuration.yaml
+++ b/lib/configuration.yaml
@@ -14809,6 +14809,89 @@ mainnet_dryrun_wallet_linux64: &mainnet_dryrun_wallet_linux64
 
 ##############################################################################
 ##                                                                          ##
+##   Testnet config                                                         ##
+##                                                                          ##
+##############################################################################
+
+testnet_full: &testnet_full
+  <<: *mainnet_base
+  core: &testnet_full_core
+    <<: *mainnet_base_core
+    genesis:
+      src:
+        file: testnet-genesis.json
+        hash: 6300910ff7d8ca51a61df661a09dfd1486be756f32eff7f348e1f4e3b6166c54
+
+  update: &testnet_full_update
+    applicationName: cardano-sl
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 0
+      bvAlt: 0
+
+testnet_wallet: &testnet_wallet
+  <<: *testnet_full
+  update: &testnet_wallet_update
+    applicationName: csl-daedalus
+    applicationVersion: 0
+    lastKnownBlockVersion:
+      bvMajor: 0
+      bvMinor: 1
+      bvAlt: 0
+
+testnet_wallet_win64: &testnet_wallet_win64
+  <<: *testnet_wallet
+  update:
+    <<: *testnet_wallet_update
+    systemTag: win64
+
+testnet_wallet_macos64: &testnet_wallet_macos64
+  <<: *testnet_wallet
+  update:
+    <<: *testnet_wallet_update
+    systemTag: macos64
+
+testnet_wallet_linux64: &testnet_wallet_linux64
+  <<: *testnet_wallet
+  update:
+    <<: *testnet_wallet_update
+    systemTag: linux
+
+# Should be used to generate genesis
+testnet_launch: &testnet_launch
+  <<: *testnet_full
+  core: &testnet_gen_core
+    <<: *testnet_full_core
+    genesis:
+      <<: *mainnet_base_genesis
+      spec:
+        <<: *mainnet_base_spec
+        protocolConstants:
+          <<: *mainnet_base_protocolConstants
+          protocolMagic: 1097911063
+        avvmDistr: {}
+        initializer:
+          testBalance:
+            poors:        100
+            richmen:      7
+            richmenShare: 0.95
+            totalBalance: 42000000000000000 # 42e9 ADA
+            useHDAddresses: True
+          fakeAvvmBalance:
+            count: 100
+            oneBalance: 20000000000000 # 2e7 ADA
+          avvmBalanceFactor: 1
+          useHeavyDlg: True
+          seed: 0 # should be overridden using --configuration-seed
+        blockVersionData:
+          <<: *mainnet_base_blockVersionData
+          maxHeaderSize:      2000
+          maxProposalSize:   70000 # 70KB
+          maxTxSize:         65536 # 64KiB
+
+##############################################################################
+##                                                                          ##
 ##   Mainnet staging with short epoch                                       ##
 ##                                                                          ##
 ##############################################################################

--- a/lib/testnet-genesis.json
+++ b/lib/testnet-genesis.json
@@ -1,0 +1,481 @@
+{ "bootStakeholders":
+    { "00a9c32607d8c8f50fba2dec2674798c33b8ad9f50fe4170db146f3f": 1
+    , "9f43183be5cf79a46ada7f5855f91f13c24bc5c30e684d371a397078": 1
+    , "b217d6b255a26ce380105950c3339190f3662ff67a73350b4c173020": 1
+    , "bf80a86feab63a24a9c24e99b2920d10617e80016a83dda06b58ca5a": 1
+    , "d2405b538b5ef360aa20f70f0b405444347140b0bbbaed7b808a5e72": 1
+    , "e9b0a0c66a03a7bc4ffa421744d44d06c9119568c9ffbe0f3d2a7138": 1
+    , "f048ed187a5d557cb7e293c147a03b67980d3adf835ff60d5dc38a24": 1
+    }
+, "heavyDelegation":
+    { "f048ed187a5d557cb7e293c147a03b67980d3adf835ff60d5dc38a24":
+        { "omega": 0
+        , "issuerPk":
+            "lka5K9yUlg/cjK4Y6xRjSz7lhOeG6V8zdHIy43RMWs4AFzeXnP16AJhlWqtUxKw5v+3nBzQuNYfdUOR9uyao2Q=="
+        , "delegatePk":
+            "aaLbNu/AtY0CGL5WtZbSjg2pl3+50gD7l4ZrRqp4XmPi+0ejmF3QTjTq9lk1mikKrkybLyiLBN2G+sDIgiX5tQ=="
+        , "cert":
+            "e967cf76a8fc34fe819c746e65f9630db6279e6a2363d03b925dd3ddd399bf9c7f2bb3fa2c1762d247aa04071d4c2d0e4aca313845ffee651a1a442c75533e0c"
+        }
+    , "bf80a86feab63a24a9c24e99b2920d10617e80016a83dda06b58ca5a":
+        { "omega": 0
+        , "issuerPk":
+            "L2n4XjMpkAEvE+Mg7KbqRUveb/vMUXCfylEIQ0IbedoI2z7xXgrcgQWv0alpY1VwJnluTE4zVLy0QzERWzdMrA=="
+        , "delegatePk":
+            "KZ+s5H5lMQxMqXUeQte211QI6hZhMHur+p3EXPgn4WO5j0D8HCtBXkp85EdWg0MHX5mtbGfXd11ktfiWxuW86w=="
+        , "cert":
+            "6a1fbfe928708a9fb93680e73877bff45b246bec70a8f55142e7dc997e2a4c10832329f7a29b507c100dcb2a665b1645f4b796f0728c9a104a52a0d16f42b803"
+        }
+    , "e9b0a0c66a03a7bc4ffa421744d44d06c9119568c9ffbe0f3d2a7138":
+        { "omega": 0
+        , "issuerPk":
+            "wHA/R4mqdHtfGpUL3LW7zLQnkbTaOz9uaSFiCX64mzbwISHfE6eQHoPKKPm+ZvA42GJehDoxT3cnX9sYIfS1JQ=="
+        , "delegatePk":
+            "EQu0gdSuZro6DPHR96b5g6e66vGqCCwx+nSEib85UpVPURSI/C5rO8cZTJLm4Vc36wqsmSWeI34BbGrMGCtVwQ=="
+        , "cert":
+            "9285f26ac40a67e3df448863900209d182da0446a39680026ebca5ddce727cc4a12a2d32d7fa91f462f6d3df20f2424751e36faf6621c51c1d96b6301185ed08"
+        }
+    , "00a9c32607d8c8f50fba2dec2674798c33b8ad9f50fe4170db146f3f":
+        { "omega": 0
+        , "issuerPk":
+            "G9JlJWqpIC+Qkp1U2Jq3BBbyNkW7rC9oi+7vtGELciUFji1n15B6eT+uk/EUQ/Ak4wXknhhYpcZ6rBTdy3N3xA=="
+        , "delegatePk":
+            "gR3HdAxv7jfxx30JPW+1DPSfyCA3bvGC4/m820i2Yd87zD++vnT+44Vtx4XlFjq6VRI5hJib0i+tUNhTT3arbw=="
+        , "cert":
+            "2228095d3f16dae811292080f2133dabca53d243bdf842829370d2fbc0fd0465a7698d53254f4153c5cf657ec0fdd52183c3cf5d112f2e30fee53727944b3f09"
+        }
+    , "d2405b538b5ef360aa20f70f0b405444347140b0bbbaed7b808a5e72":
+        { "omega": 0
+        , "issuerPk":
+            "dF4U2RMz7MRZE2wdT3l9gtBd6JjeAs9IdKVmdJAe/Uo/X39q8Zxkh7hpnoy+f6VjPKNOdH+U9pKvdIG/19ErjQ=="
+        , "delegatePk":
+            "gt+QETfxLff/at/lyjeqii1zGexMU8wKkkB8DCP+g+6MHz9NqfIUdjnLjQdrvKJ0mBNB0O+0Rwys6df4PCanIQ=="
+        , "cert":
+            "48a4d346fa7116605ac3f12f00b9d3db89021842cfd0a1622e13e15de390ea9f06eab86e15a7e6d5cec980e5eb95210216d2c1a84096b8c46462b9624903430e"
+        }
+    , "9f43183be5cf79a46ada7f5855f91f13c24bc5c30e684d371a397078":
+        { "omega": 0
+        , "issuerPk":
+            "bV+TpuFjxoJtlcjzAkbUqZi3k6pLFw4dO7aJGOwN/BWWH4gUMO5XOsn0PhRQnM3GkjdJUQpV5GwfhEkDMdu4rA=="
+        , "delegatePk":
+            "9b52lztlFqdpmjC4jztfrF1MoLDJK5F8PW5Raz7kx7CfBZsPwy1POkPIKHfO4LssRm/v/H7K0niTYUGe7Yda+w=="
+        , "cert":
+            "86705f10decaa9769e519c22ceb902e878697ec6ff1d2c81d70e64a8c4a5f0ea004cb3fbd34f653fabac52f48c5747934001c7cc9ac7a0e6086247f253295607"
+        }
+    , "b217d6b255a26ce380105950c3339190f3662ff67a73350b4c173020":
+        { "omega": 0
+        , "issuerPk":
+            "2hZRYl7pyMvsEX38af8rhPv5K18b6BYtTbgbPbUtrc3GdlRrcAE9WA0RcEiMR/buE48serYD7h6WJOUgr/s3kA=="
+        , "delegatePk":
+            "CCwc2HDia5Ci7LCYxVVW3jwqg3PPePDnP1m5vpQ7KE/O3CR0/mAdCBFzz6wbTlKHJ6hp2zNDV090HxTFeLwUWw=="
+        , "cert":
+            "70060f379a5c8a5af51f378e8de2757710d9243a405d6bb69017275aecc7cb57e52dbbe08934fc18f17ae352de3b05b0a0fe65fe2c52f14f8d51a99243044400"
+        }
+    }
+, "startTime": 1531692000
+, "vssCerts":
+    { "92dbddc858d353036eb15511051edb96c878300274eb448564489239":
+        { "vssKey": "WCECAFJSaDFGZ492OQJoyKOdRO9xNmwhtlUe7GI6t6dni2w="
+        , "expiryEpoch": 3
+        , "signature":
+            "8f5fda65dab2d7aa6f635b7bbdc0fe14fa667fdfe473e8830c46c1ef30b8cef880d8a67d16cff822bf07d77c89bebb6f8f148a938d335f62e1d4bc27d17f090f"
+        , "signingKey":
+            "CCwc2HDia5Ci7LCYxVVW3jwqg3PPePDnP1m5vpQ7KE/O3CR0/mAdCBFzz6wbTlKHJ6hp2zNDV090HxTFeLwUWw=="
+        }
+    , "ee8268c62fa962d2ae98cb6364ca8cafcd983140bac7edd56509568a":
+        { "vssKey": "WCEC3OUIYjQUBKcc9gL2lL7HV2h20w4kcmzxaF7nFVGutIE="
+        , "expiryEpoch": 3
+        , "signature":
+            "a76d14bb176cf1f64a525ce677da91948cd9b2e7c493b4e877e18a9c6d0cb3df002e2b162d1f0bcb0631a0ea37d773446e604ba5eb18cb6b10f27d038434a303"
+        , "signingKey":
+            "KZ+s5H5lMQxMqXUeQte211QI6hZhMHur+p3EXPgn4WO5j0D8HCtBXkp85EdWg0MHX5mtbGfXd11ktfiWxuW86w=="
+        }
+    , "c69e46f1bc9153640b3645ebe79be9158e9c267b87fc50196326d02f":
+        { "vssKey": "WCEC6PGFJELMMwhMGPlvqZ3mosB+xR8r3fyvyzkR5D/DwXc="
+        , "expiryEpoch": 2
+        , "signature":
+            "a256adf50ad19ecea2dc32d8a34cb584df11580490524fad268120111b48b51b30f35a746c97583574dec252cf867c534a4301dc1de8de133c43917005a5f906"
+        , "signingKey":
+            "gt+QETfxLff/at/lyjeqii1zGexMU8wKkkB8DCP+g+6MHz9NqfIUdjnLjQdrvKJ0mBNB0O+0Rwys6df4PCanIQ=="
+        }
+    , "e649d57c5f1afd5a6dcbd86b7616f1d7e03c4c2e1519cfd90d5c8a2c":
+        { "vssKey": "WCED7/qrnPG4DJSAvvd16C4PvLwW1V79YRbKXegpDrGsvxg="
+        , "expiryEpoch": 2
+        , "signature":
+            "dc3dc1a031d070ba5876f5e518cecb5fef7ef34f38bb064660aa867def60f28749a41bf9c0384ec9b55ce870e2c5c79c59600419ae1b26293b092751cd242300"
+        , "signingKey":
+            "gR3HdAxv7jfxx30JPW+1DPSfyCA3bvGC4/m820i2Yd87zD++vnT+44Vtx4XlFjq6VRI5hJib0i+tUNhTT3arbw=="
+        }
+    , "354c24be776032d5c5431ec38a2721d5022ba476d8372f6cdbcc9369":
+        { "vssKey": "WCECy4DDzXq9A/sBvCiJs7O0b7Vokb3BuPYDm42eq1/wBtc="
+        , "expiryEpoch": 5
+        , "signature":
+            "69faabc13d0cd4c87c4b9637d9bb08637c52ee6ef0b49aab0d8e775b5e686c9ec7029915a8cf7577251dc0a8611929390fb888f8cbd4f544ab884630e164210b"
+        , "signingKey":
+            "EQu0gdSuZro6DPHR96b5g6e66vGqCCwx+nSEib85UpVPURSI/C5rO8cZTJLm4Vc36wqsmSWeI34BbGrMGCtVwQ=="
+        }
+    , "0c432223bd3d6403860490c366885f7aeb2b6194cec9b7e44f9b20db":
+        { "vssKey": "WCECQgP2a1Lbah4QLnrFpebY1gfnvBqjzc3c3AIkpsqAeO0="
+        , "expiryEpoch": 3
+        , "signature":
+            "4c2d13531dbf7cffc9d5abc34a67e6225060fbf7286e1c54ea22aac0f8e3c7e8f24d895bf2a802658aa0b8f2b8e5ca21afa3c4b146b42c97e747e8b3f5e4310f"
+        , "signingKey":
+            "9b52lztlFqdpmjC4jztfrF1MoLDJK5F8PW5Raz7kx7CfBZsPwy1POkPIKHfO4LssRm/v/H7K0niTYUGe7Yda+w=="
+        }
+    , "1353cef518093ccc75e3a4585e9ef378ec232cbaad2a2316d56afed6":
+        { "vssKey": "WCEDOLD9AR6Ipbi01du5w0sd4QDS6Co8GjPLjjTnnIqitwg="
+        , "expiryEpoch": 1
+        , "signature":
+            "7c8c6577cd9ec68e7877607ee40d2a850caf12ca8e59f321ac7d5b99d0e44ddcf1d33dd9625f7d113cd7dbf2e819181b21bb84aa6e1788c43d173fb4c4f7c50c"
+        , "signingKey":
+            "aaLbNu/AtY0CGL5WtZbSjg2pl3+50gD7l4ZrRqp4XmPi+0ejmF3QTjTq9lk1mikKrkybLyiLBN2G+sDIgiX5tQ=="
+        }
+    }
+, "nonAvvmBalances":
+    { "DdzFFzCqrhsxdsSm1fsnFJLa22uzTjmzpmVJSEGJhz3xd6e7ydRmLzo37SXGBovq43MU6Hr9v5X2iB1yMfrXYNrb7fHuk1bQEKwPxbKV":
+        "19999999999999"
+    , "DdzFFzCqrhsjuWHtjd1chdKukZ4aQB3K14z99iQwGz9LfBu2nLUEhoRCqcG7hoMphCkL5jSQbNnRJ5p56zHFdi9y1ZDgd6SGNQjn28Rh":
+        "19999999999999"
+    , "DdzFFzCqrht8jMjhKTPxuMrbVixoXfmcGuVVwFmhATSnuUcYEq1HGtUpUVAxVqKa1zDGhNoADYkWmtfRMv6UVXHPUH2y7ERKoxw9JqFn":
+        "19999999999999"
+    , "DdzFFzCqrht32RFMeBKqcFB3dJFNvPp8z5YFgtBVJVtmEUNnng4bZdgzHGoZLMDdshjyS3jtpCs43ZCxhTdFPY21FvZVnZAT8NFRr6ee":
+        "19999999999999"
+    , "DdzFFzCqrhsvCGatXq3tDo6N22pcFx45tx31TbUqA57WQ8rC64qTQgDe4CXCfDcsD2kTxrNievpPzFHqag7ynWGyN1Ud62oyZQbdg6WX":
+        "19999999999999"
+    , "DdzFFzCqrhtAwCp82XgxBDXpr9Aote66kNzHvZfpGfNYvQNSRt7gUSbXmtnmHcfD3RgJ8A1WuRqnTFwBjRponqJ9HJiLKRfZjz38jwZc":
+        "19999999999999"
+    , "DdzFFzCqrht2EVFtiZVwHC6qHqEgfmNimUMoA8wueD2VUKq6BwjhQemMDXdyemrgi1XMyY5swQ6jM13AErKH6LpHBEjT51Hv9Ni82Bsz":
+        "19999999999999"
+    , "DdzFFzCqrhszyiWGZj91UkiS6o7Aa3XXRzZxfckUVoqjWBL7Y7VL4hBFS6JPH1kGALS3CQ5ch5qm2a9o7uXJsVA6aNrNusZD259zYsEU":
+        "19999999999999"
+    , "DdzFFzCqrht9yjbtPVZLcJUN3Fc2oa5FSCJdEYM6jmW9SAiZEjnegjnT2THvzNtmyUtajkmDhL3cyuG6fF1wMxS3x1gYLJcf8stPTkjg":
+        "19999999999999"
+    , "DdzFFzCqrhsnZLN2DMzjtwbaGfmSY8pohWPpetYH23fFwpvTQog4cWj1ngypn8tVSrtQ1sDSonJ16zbAF9VhUsfEjREE58K8HoY3YuQm":
+        "19999999999999"
+    , "DdzFFzCqrhsy7mVEE7gzmYPRcvdqLQbuc65sQLYHSx9aA921WihfxFcsLP5MGscEBqJh2TszeL75NguUHSstSKHZYcXvsdKNMhcjSxp2":
+        "19999999999999"
+    , "DdzFFzCqrht4bRz6aqwM3qHvugY7RFkn9WGuFmohQTtntCCLeA1mrRGMQYnBk1o5NkA9Gg6DcaWGRfv2aVnD9rmaPuJsHK7EpCi5roGJ":
+        "19999999999999"
+    , "DdzFFzCqrhspTwde4BK6TEXjCXHZihjW6v2Q8CgdkAa79fbZGxD7ytDYWUjtfapdDYW9xyTw7GcHqJ9aePTt14RqndvW8XRvp5rpsAMj":
+        "19999999999999"
+    , "DdzFFzCqrht1nzhvPnesSL3KSaxXmue6gNX5PkUJsRcitynFzBUWnjFw25N1Cvx4i2vEiikjWsiuoMxZLubd2Zb2WrBrfsatPqKVUMsL":
+        "19999999999999"
+    , "DdzFFzCqrht3pLDTjADWoFyhtHAHmXB4dRMjjzvAJobroC67o4qiKbpHzb3knqhfSGhjL7dDkgwVPbJJW9Mr8pmwpKDsgJMG7s6Roaqx":
+        "19999999999999"
+    , "DdzFFzCqrhsxX2b8JbmABAE8nsRVHCMwMSGXLrYhog7Z33KGSoLdkD62utpnYsas6w4xyUSSof1pzZaXr3tVm3Yct9i9o14qoTtwCSvQ":
+        "19999999999999"
+    , "DdzFFzCqrht2w4bHhahm256WLLzz2hJkrryS6VH7AByUPVLSY4JoRghUnCiDPVSHrLiLQJNzjmH8kbWKYEi5DRuP9upPZ9MdmYwZky89":
+        "19999999999999"
+    , "DdzFFzCqrhswTKWHRGV1uzvErYiPjUoDbY45AoyhKnFbg7HPP2LUoC21H8mNxPPGAofMBJUBCBRMmB9vTUpKs86z1Evyy7qYwZfdLGi3":
+        "19999999999999"
+    , "DdzFFzCqrhsoNbnSqVpKviFW8RwZxhr8DEpuCQNRu41Pmf1NEY9JnFo4knfYrcNXZ9VwCohLxx1HGCgGZpqBKJnCfJKXVHbByhJsw8zp":
+        "19999999999999"
+    , "DdzFFzCqrhsrcnEsqCzKhPEiuR8V1LX76UfLUTJbzb1wCzP46WW13wm6mrsRKBuJPph8h5Q8ELrYWeXsjvCdCD5seG9wmAQ1WcrGWxjp":
+        "19999999999999"
+    , "DdzFFzCqrhtA6TqnE6A7iYQFeptcnS3utjfLYeoMrZnVVZPGaVvGSKVMGEkYtemuBV322uhJrUygfFMiqG1bSFSyJNmQqdtXQTxgYjL9":
+        "19999999999999"
+    , "DdzFFzCqrhsujRZQu1LSVVdu7W9nYqyENzZMGm2ACDdh7UV2BHkAmRafBKXiVaymRwaRZwpZnyueNiPdAXv1W4G6wPZ3weyKifugxMh5":
+        "19999999999999"
+    , "DdzFFzCqrht8xHrzcr2iLSmvAwj6qG7KFMvaT2n2NbgMDt9GXJrEVpQAiihwJu3oes2Z1krKKM2NQKeN3oFEC9FERrmKELC4qPLWeDew":
+        "19999999999999"
+    , "DdzFFzCqrhsujxuEfX4mfwHvcnnoyjwRevYGwA2Lu9h1bjfWFqGRpCTsKPeVn6W5zkDPW2oyJhnuuvjEyGrUDLE8rhMZhkMWSPvsi8wC":
+        "19999999999999"
+    , "DdzFFzCqrhtDAnS82CaKhBfC4Jen5dFth2LExaQH5c1qmbCAptb6diALMKsWaRdtk3aqJ1koEq4SHE3J1wx3gMv8FPsuUBY5ifydZ9rC":
+        "19999999999999"
+    , "DdzFFzCqrhsjRh6CnzNw2yVxE4BGZBUAFXmtpsAtDaqwno8JS98f572F3RgjTJ7fsV5ccnyabrCmoaVcuEFa5LVf5SYtbYGXyof9s1o5":
+        "19999999999999"
+    , "DdzFFzCqrhsvMCAcFpKQ637NGSMeKQ5orzPTkadfS7UtX9vmx1NTLjd36M6dgjCpfrq4f1JXkj7iRqL5xeGfLxWjm2JDjyCzhA7uGqJr":
+        "19999999999999"
+    , "DdzFFzCqrhsuyEdSf6aggu4jAC1uePxham7NRQgZVSQ14Mamyj35B5ypokUr9naMrvwU6fXoVaXZbgBEeZqqXJnoMby4EZQnyD8YDof9":
+        "19999999999999"
+    , "DdzFFzCqrht1sp4aaoZSQHcrDwCWxCG3qiGQ377vEzRt2jXTc9Cjs5J7MZrWF1dsixLwffN3mFjzfpLkFvoAvmV8fJP63WZxeYg7eSsC":
+        "19999999999999"
+    , "DdzFFzCqrht5e5ALjXv5TMa2X9U4jTMJkFtSRCqZHWuVY6iXDA4TBp1MJF4qt7VBn1LgCzsirgUvJnV5iDoHZFaZU2norWLq3JFJXV3K":
+        "19999999999999"
+    , "Ae2tdPwUPEZLN2Xne3MCDcR5CS6MSPBGzPtJqi4vjsPExvNMi4HBxCMQW97":
+        "5428571428571429"
+    , "DdzFFzCqrhsvU3PfQZ3t8KFzak2MqgFC7K2AoVPLH3N7TPtT3ikxWv5RX3rn6RxJEMmCwKhf4jSqBJX4Fh67TtAfw8ibtvpX1yR3b9PQ":
+        "19999999999999"
+    , "DdzFFzCqrht3a1jT6VNwZVerxNKAP49YbGku56X7Gehbu5tRg6g5Xv39ihcuuG2KnbiW49w7rKGfvRsTWP5YPQaP3z7niWYTrtjRDHd8":
+        "19999999999999"
+    , "DdzFFzCqrht4akQuiMy2BX1yc9FRnFSFoFrxvtbTkEoxECPB1S6AXnBvKHTFJcyQvBvs15KWp9mgFy7CsFUrriKJ6jjU48YJpDp7uwaw":
+        "19999999999999"
+    , "DdzFFzCqrhsgVE9hBJtYvL3FZzqe6vAkKBFqdu8mFE4WLoWGhztc4cAaUo2FdR6CwKpo9jApf4C9X3X9egcYhp9XMEugmhKsMyyh85W5":
+        "19999999999999"
+    , "DdzFFzCqrhswHBeFpT9Zee6FuUopipoE7bKRJBcY86TxgzNnwRrL8fPMEFyuMfrsn6efhf2ZWD56Y81nNZ1Mh57aSGRRpqpZW9y3PvtK":
+        "19999999999999"
+    , "DdzFFzCqrhsfa7htaHnCs2UgreBPqdig7yBZGug1rakCDkKxKjxV2dXba5D531Ej6ETSDqk4EczLtutJzzntFpkRWrpM41XeTzHCq3hX":
+        "19999999999999"
+    , "DdzFFzCqrhtDAf5RgkRMHPvaW9tGc8RTYe689cqM6gUitWd5JHBn9GbSFT5eTh7as98LZdExn4BFGDePHh2wMfB5GDwMzRTomo7ZSLYZ":
+        "19999999999999"
+    , "DdzFFzCqrhsxDgDJAn9NhzvGquBWT1CUSQRuRxBzuLsswVM2t8PexJ4iD7Cfnbm55NPc1mHKASYvYstUMLW5o6VsZLYhXnR9gyK6VqB6":
+        "19999999999999"
+    , "DdzFFzCqrhsqh2tFdfrZbCKiNY9Se35o9ey15ehPX4GzXKfKCAsbZZJZ7ydySYwHaU6p7rRinAUrcPnzhkvMiBJ4Sf4LVwfqkC3tumRp":
+        "19999999999999"
+    , "DdzFFzCqrhskcdyyFA7M65fkpHhHvW9GuPiLgRS8EuzFmy8wtftaFRsoztJHUqzAtwDNbsj81T8TV5un8C8VjCk3uGEfda9MU6fPSw2p":
+        "19999999999999"
+    , "DdzFFzCqrhsxExdZ4ooCcAoAoTcoJUCA8mmj68kkbZJSgHRrYj46GWinqjgETf8cN2Rwyj5nTRhqh6ZEYKVznokJA14k2e3WXskcffwk":
+        "19999999999999"
+    , "DdzFFzCqrht839DXLJR6or7P6hCwnAAw5UgBRJh2wWf5ufsCCR7qH7NV33mzUbxt1xw7sg8iC8kF4ARTgnPV5D58MtyJq6gPuMA7LdyW":
+        "19999999999999"
+    , "DdzFFzCqrht5nCZ4RbqqZ6q88cdkhDM7nG5Yu1Q4Ssv7m5yeWL1u4tKVKngVdZbmpp6mGurCjzddfrcNwmbEtdN15sRECaHvv5DETa9k":
+        "19999999999999"
+    , "DdzFFzCqrhswNvtojTAEWXa1pht2bELQfP3updkescXd3KLDnVjWTdZjRiFmGDYgEo7uJ1m9vKVdBu6TZLNiUHHPf6uDGnkU4CjN9LGj":
+        "19999999999999"
+    , "DdzFFzCqrhstKiv2yeDj2aUFHvfejSR3q4CTNTPrUty6x7DtYnXVUVao97pxwWE7H8mYbqwbVWCf6NHaGFeEGvmFiB6aesyW4i8vyimr":
+        "19999999999999"
+    , "DdzFFzCqrhsps82ppBmBPWaApvuL44pvGSaVeo5g1C99gxbNiuK72R4j3wtfAxaj7B9aWpiYjFBJBn6PNZZ37m7GgQDvjvhUmyWFH3UL":
+        "19999999999999"
+    , "DdzFFzCqrht7PYCyFPUnYFk62itwjELEWhrgyXVJJjjsTquBRNDVNxRgnWr3Akdqi2MGM7zDmwWbbQ4HohXXeEpjQ6i6HVwt3K7xQvhM":
+        "19999999999999"
+    , "Ae2tdPwUPEZAB8DtYFv7AWG2fCRLCvznKS1G8D7FUEQpWZav7S1UoHchQ2Y":
+        "5428571428571429"
+    , "DdzFFzCqrht5gaQHTLxBDZp5RxvCfNABcRo4kjEj8Pw1Joi3ViUV1f92tNUPmTfan8ipnzb2Nn1588YWbhgx8WVN5ME8ksCobuSNcigS":
+        "19999999999999"
+    , "DdzFFzCqrhssdDfkvZ4FqWYpz3goo4M1dUAMYqZF3Z2ctesnEJVjWrniBpCcUtsys9UwpyMBwvnpvBUeyMTRjmSzyu22r6zhKpwesrRP":
+        "19999999999999"
+    , "DdzFFzCqrhtB1WrSJAtvHxUHkKZoK8j2WCHd18dw9kcEg9T27b3hNWTRXpoYrMsAo78GVsJDnh9pAGB3i5Z5xrbzxyUcyqkweUhJgkCa":
+        "19999999999999"
+    , "DdzFFzCqrht1C9Rw82SD2LTDRw9L3WeSYernw8TWrH92canpCZnNeCnukp95KA6rVE1VG3E7AMxXwmxzJKYwbqVm6Ea7egMi9vTqnZjP":
+        "19999999999999"
+    , "DdzFFzCqrhsqK9wbCymGGCJWwExd5YKRVRXLG7m4edaaQfrEBohU2qGjHf8EKoHcvJhXkqZqeEFNTMLEZTqygLxet13U9jYbZDSFUwrR":
+        "19999999999999"
+    , "DdzFFzCqrhtBSRyWb7GPqeQeLrdyKSdyD6CL6aPPSuGqvsHxXBv1xJxLiZBTFNA6KuMLZxSDr6BzXyt7evgqaoZoT4SrUHnNqTmuPsDP":
+        "19999999999999"
+    , "DdzFFzCqrht5TZJryHF2tG4a5886MsX3tUMdiLbA4bdE66zf8Y24TCk9vduqyBVdpdvcm7uGG4jSAuiBqtKWQU86985fCZuzEtdRQMLm":
+        "19999999999999"
+    , "DdzFFzCqrhsvAEwwHMq6DtWwbicNu6UiuAroZ53Cow6ucZoWHcxPVctkEv2fLmPyxcHVeEEn8pjTryyuxizGe7nw66VADcANGkmeqJYv":
+        "19999999999999"
+    , "DdzFFzCqrht11AxF1GWdU2HTzXmrtG96bbQgQdL815viWWCDNkSQan7rSq8NUxzZQNQGwSXFetFmPTTE4XrSMJkCopnwJdkEDzePL7P2":
+        "19999999999999"
+    , "DdzFFzCqrhstexC6dvVjS3mbDgeUE7wfpkrs841CkbbkPkmAVoHjAnYyouTUMc417XHXPssTzJvxTu8A4Dcs8BPMMVpHJt5hKRs6Q91F":
+        "19999999999999"
+    , "DdzFFzCqrhshzT3G2hY14d3EAVFQyz8GKwKfuf5u4XDasnfbU7ZWiEqcadXzGT6oQienzrSoFa5ZZceTh3u8xJVczF9VQiccpBrsDQAv":
+        "19999999999999"
+    , "DdzFFzCqrht4r1pL4HAQHzmfAx17nXidzmdCSQsUGvBowAeACh9pMYgAqPgmCBCCFwkWoVmgJG37xUaMh1cenz3VDt2ioJeGmUYyH82J":
+        "19999999999999"
+    , "DdzFFzCqrht74HB2JuupMAcDc9Ddq5cJ8RVcUG4VsTvSgPJPhCggmiHfwCzBUhfVwRdXXDiBcYHKvpmGeErorxZfxydNQG6kX1gizpRq":
+        "19999999999999"
+    , "DdzFFzCqrhsgwswt9BbCD3UxHYMJKQAEYYz48qefXnWbFmxtTzZMETnxveeJEyMesQfT31BJBjBHrfvMX3Af7e978bvgtj7uRqYcxEFG":
+        "19999999999999"
+    , "DdzFFzCqrhsr6V2J1wgqfnz8bsQrgs3p81ijJy6yfTnYB6hPaYtMkJaC3MW9488QjuuK2LSrQjgky8Tgs9fZwP2Wus3WznbnD9aN3UQj":
+        "19999999999999"
+    , "DdzFFzCqrht5BfYxpKdzjDQkcF58qWFCQFdV1ov4Jinzx4rCCyGHSvojA7wst3yNcyn3dtPgNZzsDUJ32M9qCQk1WyNAnwY7QNjtiFYz":
+        "19999999999999"
+    , "DdzFFzCqrht2p7DGg5jdT3ii9yeJKNAwKu6TnN3HVS577LxU4npCdbxVWCmsm2Y1neQSRWGiXcAB1NpS182ambmkQuLJfLMByBbYbyZG":
+        "19999999999999"
+    , "Ae2tdPwUPEZCZ56X2C33r14yXcE8WZNWPGdNVBrxuBmWhCewz9Bfdk9aoLU":
+        "5428571428571429"
+    , "DdzFFzCqrhseAhsvrTUMVMDJqXi2GCNVaMPW1iJq38MWfdxNM3a17ACVM3sBDbqcLS5yiXtdLycgXTtKLnWYtkRoHcNjh5TUVUgrPgbU":
+        "19999999999999"
+    , "DdzFFzCqrhsuBhhwSTXEYHmJkNGhmXcDrcx2m6LvXSmkEmmtM9DvFrkx85mLcCaGQuFNgZZBnD2XYedNsNnnbS1jG4DwsiPhQWFtY3Tt":
+        "19999999999999"
+    , "DdzFFzCqrhshucFmGzLPBHP1Ztf3sGt2oCxGG31FXsYhK12fMQ9AbV7mWVNeEPwnNYeG8TvQZmNAzZZ1bUrJz5LXdnT7VHX1dyEh1Wok":
+        "19999999999999"
+    , "DdzFFzCqrhsi49og8QaHvCRJEWNhhfXYUeryiqhU5KujoGYW487mXi9tFEsYdfTaNuct7NaWPhrJFQr87wqzCqwKMy9K34deerHGVgiF":
+        "19999999999999"
+    , "DdzFFzCqrhsjXKdztoizmjUdGFZ2pPidc5qauEvJnS1Db5XG6Aogu6RFTpWH4xMXucPq5BXr5d6vqZAtVVQ4EZ5Dh4Jj7kWuJ4Xr4PXV":
+        "19999999999999"
+    , "DdzFFzCqrhsehjmuS5SEEuk8n9rG1GgTETZvRcMMN8wM2gK4qJ5uuUjCDdyi8YHEDu9cANYgNmLmH2QoNMEn3Q7kqYCHUGUy5v7cGmBU":
+        "19999999999999"
+    , "DdzFFzCqrhtCLe9LL1fALd5oyD2HusY1U2Vghg5wf7uBbtdkGsbD43aGexyHNdWM5ZBucjZrxmc1c1qCFBxAWiYJgq56zUE2bsJ33AQw":
+        "19999999999999"
+    , "DdzFFzCqrht7eKnD2whXQidYs2doQyxQan5KQ7PAKrZtRCQq3bMaB2mgwuN9SiGw8g4ZZXNPnUgK8h64VaT41m9Dd6TGWpzcMFwWQGZu":
+        "19999999999999"
+    , "DdzFFzCqrhsxhiK36VKwZSmUCpBwaNEMNMfCnUqZHF8ZfV8AQwa1T3LYBVC8VCWu8pJYEUKQDJBvDFso22hJfyuCZ5tab7Au79hJKLtA":
+        "19999999999999"
+    , "DdzFFzCqrhsryn1oDA2Ha2j4qZs5JUpuiw8jevQqFgtW5a57jBX95wAcgDwLm5v1gbrcVzBWr8HCydnzYAiAL7QHMyJcsQQHqrqmcsvn":
+        "19999999999999"
+    , "DdzFFzCqrhsgq166tFLaa3VZfUcS1142yS8eHigGybvjHZPV7eiRA1eDPFEz3Vg17cXaYEu1s7P7gu81G4KQo6Qg6WXBxRyzHPVq1xTn":
+        "19999999999999"
+    , "DdzFFzCqrhstFvqWnMumMABzHzfhRLWTYqFNcHPDw5gahMwiKGxmMNZR11YuoMP7cXDGV1aLRis9fzXRmyBsSYJPjpbefVgXu9VTYaYi":
+        "19999999999999"
+    , "Ae2tdPwUPEZN5aWiXCueHo32N6Vgdpn8dzWnQSTLBerCP7CP4dxPM9EM2Mq":
+        "5428571428571429"
+    , "DdzFFzCqrht1h6KtX86LpEazp59KoLjKstKWLsNL3rHgsmZp6U7b91udj99LmqrEEYMVadQrQmqgSzqcsETtbbU2b4ESL2e2rEh6rJr3":
+        "19999999999999"
+    , "Ae2tdPwUPEZ61PR8Va9Hae3AP321WfUcbNAbqDRAhYaaFXQnCqBoEgNRjRs":
+        "5428571428571429"
+    , "DdzFFzCqrhsfZ92GyHjSdDBxBSuEvVM3VVNLPsQcVW2gMouJJBaavmk3scHvv4gKxGc1xgfb5mh7YakHGGiNu4K3sUP5gcAeaKsmSXcN":
+        "19999999999999"
+    , "DdzFFzCqrht879HCqPUFyxbB5c1VaH2VbUbsXEarcuxYeh4HSk36zD9bCy4T9bSiRQhK14D9P7iHoiURczhSacpazXhejV5LgQJAogt3":
+        "19999999999999"
+    , "DdzFFzCqrhtBwbnzJYRYgExaj3dZhEKzLV8DJc56J4eUnbGGGHZrx3Y1e3QYribuuCxAirFYDay2GLcuJfCxfVzgsbjpWmjeFSAiVgKn":
+        "19999999999999"
+    , "Ae2tdPwUPEZAANgNqcr28x2Snargc4JpZLNgZnsBPAXkZts2soXHZpdaQwG":
+        "5428571428571429"
+    , "DdzFFzCqrhsoQC5g5ZfpBsZELhXRQ6xTT4iJcvGW1osFRXiksvoX59yqXLvhL49nrEMo1pPgxjHSSTQtrGVDEGJZTWhzxB2U3vqHhfZA":
+        "19999999999999"
+    , "DdzFFzCqrhsnPyP1mtHX6WC1Lo5v9DkD5bwKKcS26X2zjCrPLj42bAn2V48D1KW1vZHr8vtr6a13e6mEuoCq5c5DFkbYUmcbEvMTuGsu":
+        "19999999999999"
+    , "DdzFFzCqrhshxUqMH4vU3wiP4nUfLvo2JFeYGZUhMfys62qiAmp4DXAMrVURFmkcdprjHpy2ueXnX8V8sNzn5PBB58anCHaU3VBzepDU":
+        "19999999999999"
+    , "DdzFFzCqrhsnn2TpP1xHemgpuCawJs2ede32vxjvjvzakoscwe8Xv1uhDbnn5NZqHq7QrWexBs9Jm37gpSkojJgaxiFjZG61Qwhy1uZh":
+        "19999999999999"
+    , "DdzFFzCqrht1QTbD1gcYDLP83pnGxN72MsR8EaSkDwdn48vvaCwbtrNH1kvKxkGZFMy4DPLWzb2an8eBG5Jidftr8LWH9oLx6d5VnN45":
+        "19999999999999"
+    , "Ae2tdPwUPEYyzNVJ6ggmvVjpKxqMN1m635vmc4edRYbQoaF5bXBzZEQTdxn":
+        "5428571428571429"
+    , "DdzFFzCqrhsfSbsb3cdamfcUk8FbrduDSN4UXN7bHeBTR9UydhDpTrv7xB5p9v1w8fc3Pp69kEC23stkgmsLQHVYcqXyn9LtgksPG9dF":
+        "19999999999999"
+    , "DdzFFzCqrhtAtYSW536SyFUpB3b3jXVF3BhGTN3qu9FyqVxvt43Sk4733urgCMi4a71BKR25HRsBB59so7WeJgmxNwkwJBLHsv8iFZuk":
+        "19999999999999"
+    , "DdzFFzCqrhssoggin94NmpE1mAgqKCSVqiXnFinSge4CutUxD3TNGSbTMfvcFuXTBkM25SWgGVZzVCAvTU4kjpqhdgcJhGZFM2YWPkUP":
+        "19999999999999"
+    , "DdzFFzCqrhsvDxdkvFAQQiW7jbBHS8d6sgY8x1MqN6x78gBsRBdTzYvpo3gkQh2vaDxLTPfmQj2XL2VcnSBPL422LHqdjspjJqov6zkE":
+        "19999999999999"
+    , "DdzFFzCqrht8NHb4aWnxyeiED1j6hih3XU7YYkidmQ6jEmkk5pYhkZQfqQgZfmL6Xau55w23TbpDRnS4rFB4X2WqRb5q6WMtxTk2LSNW":
+        "19999999999999"
+    , "DdzFFzCqrhsyYi4icnVbL6SMKNFLs9foWcruwjpLHW1QwjsjyCwRtysUG4zRD19ZKYaNcDxN2MN9RdGqEPhvAuf9XpUuaGchZB2eLpBN":
+        "19999999999999"
+    , "DdzFFzCqrhsv3rHMmdDH6nV4FpuLAi8peVmXpW4jF4Timzek836pK1Sc9fV5QyNgfmDhJLMzfMeJaKqv5hM3tJfT4CNp1MchjPBCfE6N":
+        "19999999999999"
+    , "DdzFFzCqrhst9RHfsjMCC8JW4iVBWkJvdYiDaL6Yu7PketRGo89R1CeSTbdxZV4DqTXHZLnhz3NUBQue7QvuGHkxDNd7fbcpz3o81MtS":
+        "19999999999999"
+    , "DdzFFzCqrhsnEwPMQS7UKbWE7MHsw3KCZ565g71YeqwbfVsECjR8k9QVbbqvfSevZr24vi2Q9JwQj6GNXzvoiZ2iza2VVktFHsVA3dyM":
+        "19999999999999"
+    , "DdzFFzCqrht8GyFPoM1BXLnoukEoGrbu2eJ3fvbqNJxUiifVGq91LGFt57sFDnTagFmwvMGT9q5RLGTpNZ5Qd7ybH32AXWwmXNnsFP3a":
+        "19999999999999"
+    , "DdzFFzCqrht7AkqP4G3Kfm6TNMAXQFoumBF7Bn5uHNksuDizdu6Pc2GuqZDgAe1M3vDZ6P37VYG4p9NraQuELkVFQaHPfJAgjBe2EQ82":
+        "19999999999999"
+    , "DdzFFzCqrhstwSRE4yzVUp7BWkveXmaHJrXyZCQL8q2xG7rY2ta33gCSLgowQB7Fh81dKJ61Hm68zfETpWzBM1JMVgQdLwfsPA4AHWm5":
+        "19999999999999"
+    , "DdzFFzCqrhsvXE6G1zrCSKdhBuTatK62EFAmyqmBFaMtsMo9AkZny5TUSobomnGtYSCyg3KCXWnf7UsLxJKuuCWZtV4BWuEXW8vEMPZH":
+        "19999999999999"
+    , "DdzFFzCqrhsxiK4bTUWabpGS9qDfDHLKizMtg188JfhfyRuLEnPFx6FW1SmDECYpMEGVs7yYbXoae69qzpkANnK6tWacHqegWSmgAPp2":
+        "19999999999999"
+    , "DdzFFzCqrhszmhyFpYchfJpaN5BXAQtJL4i5p6T5RjDoqaXXrCTD2BjnpWpdSfi7HWe8Kk497xMq5KGkJABi2MpMfcRzTUvRpLr2WBRg":
+        "19999999999999"
+    }
+, "blockVersionData":
+    { "scriptVersion": 0
+    , "slotDuration": "20000"
+    , "maxBlockSize": "2000000"
+    , "maxHeaderSize": "2000"
+    , "maxTxSize": "65536"
+    , "maxProposalSize": "70000"
+    , "mpcThd": "20000000000000"
+    , "heavyDelThd": "300000000000"
+    , "updateVoteThd": "1000000000000"
+    , "updateProposalThd": "100000000000000"
+    , "updateImplicit": "10000"
+    , "softforkRule":
+        { "initThd": "900000000000000"
+        , "minThd": "600000000000000"
+        , "thdDecrement": "50000000000000"
+        }
+    , "txFeePolicy":
+        { "summand": "155381000000000" , "multiplier": "43946000000" }
+    , "unlockStakeEpoch": "18446744073709551615"
+    }
+, "protocolConsts":
+    { "k": 2160
+    , "protocolMagic": 1097911063
+    , "vssMaxTTL": 6
+    , "vssMinTTL": 2
+    }
+, "avvmDistr":
+    { "Dh1b1lTQMIdiLKh6GbVcBzACTEdIWYZEzIAq65t2FN4=": "20000000000000"
+    , "Ds9Bk626o736HQ9LSaslefn6i2sbi5iCL2Q0z5ag24E=": "20000000000000"
+    , "eGfTaSUDFEUBt8SCc_XS6RCpLZlj1neJxe-GstpQlpM=": "20000000000000"
+    , "8br8hOcUU2BJI7AMKl6deDNgcKwhWFCR8Z4LY1MDp9k=": "20000000000000"
+    , "qjBA9FASvtidJwYGkFrLZym4GuxSwmA9y8XhzYQmdb0=": "20000000000000"
+    , "TuFb6CHnHyhp3Npwyf7xOdmI7c8biybg-6YXDVgrdBo=": "20000000000000"
+    , "Zi1rFWN9E6en5Al6LLVAM0x4vXADza8XCiRcGZWarOU=": "20000000000000"
+    , "HkVA0JL_IovjrUU8Qi03joYsGp30ldZM-fWlEbx9be0=": "20000000000000"
+    , "Y2G7hQ7WrS1UsNW9m9CLCsvImRBl8upCdtS-Ww9KMGA=": "20000000000000"
+    , "aaFogUIZUE9VWNVaP3K4c3WquxM9G1c6xKxaq7OgFnk=": "20000000000000"
+    , "EJ0dLef0XCL2AroVOFuxXY8eebpBBWR6iYXKVs3qSvc=": "20000000000000"
+    , "UtTtu58MUX-lOawleAb1B7eU-BJrv8TkTijwg8g5OE0=": "20000000000000"
+    , "cvJcSNiubJiJ9DIBw1JG5mfC8MP-yspcJAxSmU9m5WI=": "20000000000000"
+    , "D34xGlOZEVxZleHpF_7biyhXLzCSwNylXhdpFfLJf4o=": "20000000000000"
+    , "FLx-st81HrEVZ0kG41-5C88hQQn0HAcJfp1R7M4owtQ=": "20000000000000"
+    , "6bwjX9OqeJCFizLsfSQu2txUVZbEnanr1jUX9z1WSME=": "20000000000000"
+    , "xTBCuTDCuctaDAtxTWyO_ucEAJ8qrj_zzWsEiAR7JSQ=": "20000000000000"
+    , "aTFirrrPHPtna_cPaqKSJutTOAofzwn8rzaSroStZfM=": "20000000000000"
+    , "FMZH_VxCoB9DcDfcvr6GjX_5QkD-qE6EAaMvxyWGBd0=": "20000000000000"
+    , "SXiWzUxE5nrc5zlnQdrrPUG4JUx85LmckqRJvs1h4JM=": "20000000000000"
+    , "chGr5LKzyEdQPWdBvDnaOxi_GOVh2SjJBdaT6OHwKQM=": "20000000000000"
+    , "KSU7xGGG7hYUcbnNPuRsk14fWxFpE2lr3yl6FLgAOBA=": "20000000000000"
+    , "WWoHQaMDge61zCaU8uloLQALHTrmEYJQL9kC_NX-4XE=": "20000000000000"
+    , "8mJDpyMNNXs9ySY9tiPN1JOGrk8eBlI041qpMvUDQ9Y=": "20000000000000"
+    , "yE6_542Yt6NzBiZo6HEj-8QHxmAhkdMnHEFqq54ulB4=": "20000000000000"
+    , "WBMzbglq20gH1XpQOl78_oKE479Bv4d2z2udTsRnkTw=": "20000000000000"
+    , "PDpX_E2QuoOyCXZRDzUfp7WjMkdQjI2zDU69pz5M2HE=": "20000000000000"
+    , "g-GXlERjAxetIyUSB9pWQ1ACZps7tR-XBsjpDJcRBJs=": "20000000000000"
+    , "e34JjNMGuQkPX_3qY9ajW6Nr4e3sQk1gH5BorayXRMg=": "20000000000000"
+    , "kocUxcds1GvDfvi6on_dPN3qYZq1gagKl-L3cActXlA=": "20000000000000"
+    , "YxQe1eZu-k2wIP_GFSYdeQ9n3cM5epfvoUHVcjHGEO8=": "20000000000000"
+    , "TmrlhKnu-_ykt9AqAdNe9W9WGvf_OKkUboSJZXvzM3c=": "20000000000000"
+    , "8fyWhY8krCWqqWa4ZiacLGjhBBaGIqeDNIX7IlFrHLc=": "20000000000000"
+    , "KQiiifJgHXyaft88Jwc69w3bi9L_RtOpYH5Jg6RWtb0=": "20000000000000"
+    , "AEjai68nhPBEVZjSVwFbT0D5CIWBNIjIudV0mlPRslI=": "20000000000000"
+    , "ip2pNpFaKGmpINMvXxbLeTQjtD9atatPJqOsmstTsrg=": "20000000000000"
+    , "1rgie3DofKzmPE0_zLU-WqwkdVGBhiSe6tP1HNCqbRw=": "20000000000000"
+    , "BS2gP_RDszeUozyQ8Tzi3olJ_ZwsepZURk6TKoPGTrE=": "20000000000000"
+    , "o2KneL9_TPzPB5icrQbwSKiCTbdvoJLMhTu0zw2i6tg=": "20000000000000"
+    , "SAbpiv1GZZEuJl8WIu1z3kTf5Q_snHD447Q379L5vI4=": "20000000000000"
+    , "3o0Q3cLM9-So9DIreVSjmTZdFX8MNHhSqHr0cRobNmA=": "20000000000000"
+    , "c1Ge_gyJqkppfwh33hKoapJjmytnWAumH9j9oFRcfMQ=": "20000000000000"
+    , "n-oT-ATZWUiyHDqmfOrKjHuMooDjXMkcGusSAgJ6Ek8=": "20000000000000"
+    , "uAKzyKWOHJU4XSaLmPeMuLRNg2YF-dsrkscW7aQEtRA=": "20000000000000"
+    , "Q62ZcNWHHeUwNAqgeCMBaHtoeZQDeQ09igyy-Xy_dcU=": "20000000000000"
+    , "ZsXUcsHvIS05q9LX22gVvL3gBPnEXgj8EMiuxU5ip_0=": "20000000000000"
+    , "NFsKjzegO8o_-pwgpQDaHCBIb-IiEe1Lh-uuT5THCxg=": "20000000000000"
+    , "SoQA7v-YCo9NY58QlEdaxHa7CB7tkku-rytJd7ozVDE=": "20000000000000"
+    , "_4qotcAit6bDlp6vBtet-RQCWh5IGoaaH_9uPcgCEHk=": "20000000000000"
+    , "eSU19XLetcFx-jEKQ1-DLe0jI633D6KB7VDXhsZJpsQ=": "20000000000000"
+    , "7SEZJpTgZz01W4uIvFHaRu7P2Z9oTa5SzRpUKQhMMZQ=": "20000000000000"
+    , "_0cJzmOzakrN6NPOOy4n9LD7u1cVePFdqcHd0cHxQC0=": "20000000000000"
+    , "l238Qujcggm-fIaPtqIj9MnO-b9V1y47mG_P_MjwlOA=": "20000000000000"
+    , "_x-jIWEX4Hk8mt4COyWpt0e5okQJf5iYeSMLMOtKsY8=": "20000000000000"
+    , "e6UW4seBmHaHk_DyBJ4MMqEqaNHe4iHlVCN_4o3Bt6I=": "20000000000000"
+    , "VvSUYRm9xhm3ZKNCROh8rqQoE-_vkhEHr-qYGWW7eLQ=": "20000000000000"
+    , "E8sZluJ3afJEBEBH8Yapj0BBxpgH50xVyuNY_THTlAQ=": "20000000000000"
+    , "YoMfpP9lPECp2modGbNYW0xjNgUj57qb4RDi2PDAO6M=": "20000000000000"
+    , "ID4hk1bd26IDDpYFxJMyDVxvmyKtzsW9P-6w5GW7_Vg=": "20000000000000"
+    , "X276yrCIhqWs7Z_NcmzULb1UQAzRSrRwe7qvwMIsmBI=": "20000000000000"
+    , "rx-GLLYTzD-JY4AkM3X5gSZrPu1CgeR-815-OxCJmJo=": "20000000000000"
+    , "FLwPkjYLkcyk2I4w8CHACZTDMca_DZ-KfTzUGLa9O20=": "20000000000000"
+    , "T2XHbhi3ayeBB1gQ4Xcbk_Z14afu2yaGi_CuFvm84Go=": "20000000000000"
+    , "UERrFU0fXRbH8CG9wk5ijHzZcEqpn_azOkGOFJ8em5s=": "20000000000000"
+    , "oEfZTU3BVN2agEyPezaMDVuasoO5TWfYiXUjPJgLDOY=": "20000000000000"
+    , "FvS4YwTjxQlNjgFCiSpv-8QjA4_ZwA5wmrloCkJ6pvM=": "20000000000000"
+    , "yd75pgN9nTQ8i3HFDb0hQk2oxy3CoZQSM0vSuqYZfo8=": "20000000000000"
+    , "K8gUVGsehdxKVQWgD1U57KG4IIsxsDodX2tjWefEZdU=": "20000000000000"
+    , "2UfxfnXK8_kuAz4R-f46M1JLwPVVJNp_p8lV8Fcs5WY=": "20000000000000"
+    , "6-cMO-aGtF4xn6LCkH9BSs7HwZ24HLDUZTBbI_2Ophw=": "20000000000000"
+    , "ZhiN815vDf5XjnT2tTH5a8U_k-VzD6ebKADD9k5Esjo=": "20000000000000"
+    , "qrQAbQQZjB2mWFBm-si8IRVViyLhulqX71FcSmeHSYY=": "20000000000000"
+    , "gCxBuvZkHdaOpZBsAW3nqsME1qziWGxTQDbPxoMa0PQ=": "20000000000000"
+    , "5syvRT_HO8UMYCKjQo7DHZgk-nHMr9uq89iR-q0uUNc=": "20000000000000"
+    , "mtP0JLKtbr8Yebp084OvAYT8oAPwYDkOJCII47iWTTg=": "20000000000000"
+    , "I7qJyZrKvKTZ6kevvw6_l7WtpWRtxkWiRI10Qef8Vlk=": "20000000000000"
+    , "frdF8GpgENzrVypp20Z9Wwsn78U-ZY-xaIgARatC1EE=": "20000000000000"
+    , "GeShTPqrzNls3IITn36KqCiwusDB-NE352jFf5hEDqs=": "20000000000000"
+    , "ZmTd29-CHbQJLaqvRcS0Zs4h_vqQfTF-eXCWiJZWwHM=": "20000000000000"
+    , "RD3N7vrPBjqxYXYitSlsBgmgSic16EUvEKU0DLRKfjY=": "20000000000000"
+    , "nPU0U3R0rDhlQhJG-yZbvjgmusCTp0GUWOlcSpUperg=": "20000000000000"
+    , "c07tsp59NPu0nicHDy0nGF2sDGvmIxtJqUGHZc7GHW4=": "20000000000000"
+    , "ZOQZvtIMLiUdslVneCygBhVUfxQgyVSuEXqq8EqVlEc=": "20000000000000"
+    , "KKCNVeYu1vMM2_ZnY8Zzk_YBb6lx87-jxzIX2P0PAiA=": "20000000000000"
+    , "f6XicmzDnlO6o-3mbC5pnHosV3fvlz7nekMJsI5udiE=": "20000000000000"
+    , "do1BQSAyTeLhcxkEvPqo7EQDX4yQArFlevt8bsAirjw=": "20000000000000"
+    , "h_3hmG1zTkEcBdgTG3tV7cpg-0VbxWX_NyNmcr1Wqns=": "20000000000000"
+    , "QdUciUE8Pg0suk6yU4OIZ-P3p4noEOkhwT0hxoYSAJ0=": "20000000000000"
+    , "dTyfZbreXW_SsvwPBRX9kZ4qrQH6x9by2ZvhMr3Y-jk=": "20000000000000"
+    , "OyS8U5q-deGju3O0EUzXcsSZgDDQBQ1NfLWrVi5yWjs=": "20000000000000"
+    , "t9C26tbsyGoLTE-R5h-V2lQBk3MwKXFRsOuav8FDc4k=": "20000000000000"
+    , "bUGJzXsRLmJHjxC-ZRzknSst4Gco3woVAuk06pW5pMw=": "20000000000000"
+    , "lg28Ni2r4-X1d8nmiGR4GddAD-R3Z8erlvAi1K5WcOc=": "20000000000000"
+    , "kuxk5oVgLTe3AGxaBjDgK_BXFVMjKZPJxaY4yRz4brY=": "20000000000000"
+    , "0kSgoX4kwgX8GwbIdCkc5aKLjV7HUQlyYtEhDexKu-c=": "20000000000000"
+    , "yo8T7TKlBwssBS4HA0QTq1x-8ymLtW9xoOOspVEuCAE=": "20000000000000"
+    , "0tuzBzTeFLr2C1OOs0PzRr9w-FdrHGvibdyk8-SEYPM=": "20000000000000"
+    , "t4wZMkG3-wyvGaR9uTW0xYrvpKNZQ85-kBSP--PjItQ=": "20000000000000"
+    , "Yq8nGXittgNXcGCmm_jLNBx-KSZBVhd0mkvVAYyVSac=": "20000000000000"
+    , "gKQr1SH40SvzCg2fKzTq2zNAgTsysnPICr_FfLyTJRU=": "20000000000000"
+    }
+, "ftsSeed":
+    "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461"
+}


### PR DESCRIPTION
## Description

Includes:
- `testnet_full` configuration key.
- Testnet genesis block JSON file.

Tests done (using importer, backend and extension):
- Sending txs to self and between different wallets
- Daedalus transfer

Examples commands to launch:
```bash
printf "wallet:\n relays: [[{ host: relays.cardano-testnet.iohkdev.io }]]\n valency: 1\n fallbacks: 7" > /tmp/topology-testnet.yaml
stack exec -- cardano-blockchain-importer --topology "/tmp/topology-testnet.yaml" --log-config "blockchain-importer/log-config.yaml" --logs-prefix "/home/ntallar/Documents/projects/icarus/logs-testnet" --db-path "/home/ntallar/.icarus/testnet-node-db" --configuration-file "lib/configuration.yaml" --configuration-key testnet_full --postgres-name "testnetpgdb" --postgres-password "mysecretpassword" --postgres-host "localhost"
```